### PR TITLE
Use docker compose to run frontend and API

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: "3.9"
+services:
+  backend:
+    build: ./go
+    ports:
+      - "9000:9000"
+    volumes:
+      - "./go:/backendcode"
+    environment:
+      FLASK_DEBUG: "true"
+      FRONT_URL: "http://localhost:3000"
+  frontend:
+    build: ./typescript/simple-mercari-web
+    ports:
+      - "3000:3000"
+    volumes:
+      - "./typescript/simple-mercari-web:/frontendcode"
+    environment:
+      REACT_APP_API_URL: "http://localhost:9000"
+      FLASK_DEBUG: "true"

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /project
 
 COPY go.mod go.sum ./
 COPY app ./app/
+COPY images ./images/
 
 RUN addgroup -S mercari && adduser -S trainee -G mercari
 RUN chown -R trainee:mercari /project/app

--- a/typescript/simple-mercari-web/Dockerfile
+++ b/typescript/simple-mercari-web/Dockerfile
@@ -1,7 +1,13 @@
 FROM node:16-alpine
 WORKDIR /app
 
-RUN addgroup -S mercari && adduser -S trainee -G mercari
-USER trainee
+COPY *.json ./
+COPY /src/ ./src
+COPY /public/ ./public
 
-CMD ["node", "-v"]
+RUN addgroup -S mercari && adduser -S trainee -G mercari
+RUN npm ci
+
+EXPOSE 3000
+
+CMD ["npm", "start"]


### PR DESCRIPTION
## What
<!--- Write the change being made with this pull request --->
Use docker compose file to:
1. build Docker images from two Dockerfiles
2. set port numbers (API:9000, Frontend:3000)
3. connect two services

## CHECKS :warning:

Please make sure you are aware of the following.

- [x] **The changes in this PR doesn't have private information
